### PR TITLE
Remove unused override

### DIFF
--- a/android/src/main/java/fr/bamlab/reactnativenumberpickerdialog/RNNumberPickerDialogPackage.java
+++ b/android/src/main/java/fr/bamlab/reactnativenumberpickerdialog/RNNumberPickerDialogPackage.java
@@ -30,7 +30,6 @@ public class RNNumberPickerDialogPackage implements ReactPackage {
      * listed here. Also listing a native module here doesn't imply that the JS implementation of it
      * will be automatically included in the JS bundle.
      */
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
It is now unnecessary to declare JSModules. Left the method for back compatibility...

should fix #3 

see: https://github.com/facebook/react-native/commit/ce6fb33